### PR TITLE
Junit5upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,18 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.4.2</version>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.4.2</version>
+			<version>5.2.0</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -80,7 +80,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>3.0.0-M3</version>
+				<version>2.22.0</version>
 				<configuration>
 					<skipTests>${skipTests}</skipTests>
 					<skipITs>${skipITs}</skipITs>
@@ -97,7 +97,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0-M3</version>
+				<version>2.22.0</version>
 				<configuration>
 					<skipTests>${skipTests}</skipTests>
 				</configuration>

--- a/src/test/java/com/manus/noteark/notesvc/controller/AbstractIT.java
+++ b/src/test/java/com/manus/noteark/notesvc/controller/AbstractIT.java
@@ -5,7 +5,7 @@ import com.manus.noteark.notesvc.AbstractTest;
 import com.manus.noteark.notesvc.NoteSvcApplication;
 import com.manus.noteark.notesvc.repository.NoteRepository;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,7 +26,7 @@ public class AbstractIT extends AbstractTest {
   @Autowired
   public NoteRepository noteRepository;
 
-  @Before
+  @BeforeEach
   public void clearNotes () {
     noteRepository.deleteAll();
   }

--- a/src/test/java/com/manus/noteark/notesvc/controller/NoteControllerIT.java
+++ b/src/test/java/com/manus/noteark/notesvc/controller/NoteControllerIT.java
@@ -2,19 +2,15 @@ package com.manus.noteark.notesvc.controller;
 
 import com.manus.noteark.notesvc.pojo.Note;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.junit4.SpringRunner;
-
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import org.junit.jupiter.api.Test;
 
-@RunWith(SpringRunner.class)
 public class NoteControllerIT extends AbstractIT {
 
   @Test

--- a/src/test/java/com/manus/noteark/notesvc/controller/OwnerControllerIT.java
+++ b/src/test/java/com/manus/noteark/notesvc/controller/OwnerControllerIT.java
@@ -2,19 +2,16 @@ package com.manus.noteark.notesvc.controller;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.manus.noteark.notesvc.pojo.Note;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.Test;
 
-@RunWith(SpringRunner.class)
 public class OwnerControllerIT extends AbstractIT {
 
   @Test

--- a/src/test/java/com/manus/noteark/notesvc/repository/NoteRepositoryCustomImplTest.java
+++ b/src/test/java/com/manus/noteark/notesvc/repository/NoteRepositoryCustomImplTest.java
@@ -8,7 +8,6 @@ import com.manus.noteark.notesvc.AbstractTest;
 import com.manus.noteark.notesvc.pojo.Note;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -22,8 +21,7 @@ public class NoteRepositoryCustomImplTest extends AbstractTest{
     @Mock
     private MongoTemplate mongoTemplateMock;
 
-    @BeforeEach
-    public void setUp() {
+    public NoteRepositoryCustomImplTest() {
         MockitoAnnotations.initMocks(this);
         noteRepositoryCustomImpl = new NoteRepositoryCustomImpl(mongoTemplateMock);
     }

--- a/src/test/java/com/manus/noteark/notesvc/repository/NoteRepositoryCustomImplTest.java
+++ b/src/test/java/com/manus/noteark/notesvc/repository/NoteRepositoryCustomImplTest.java
@@ -1,6 +1,5 @@
 package com.manus.noteark.notesvc.repository;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -8,15 +7,14 @@ import java.util.Optional;
 import com.manus.noteark.notesvc.AbstractTest;
 import com.manus.noteark.notesvc.pojo.Note;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.test.context.junit4.SpringRunner;
-@RunWith(SpringRunner.class)
+
 public class NoteRepositoryCustomImplTest extends AbstractTest{
 
     @InjectMocks
@@ -24,7 +22,7 @@ public class NoteRepositoryCustomImplTest extends AbstractTest{
     @Mock
     private MongoTemplate mongoTemplateMock;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         noteRepositoryCustomImpl = new NoteRepositoryCustomImpl(mongoTemplateMock);

--- a/src/test/java/com/manus/noteark/notesvc/service/NoteServiceTest.java
+++ b/src/test/java/com/manus/noteark/notesvc/service/NoteServiceTest.java
@@ -1,23 +1,23 @@
 package com.manus.noteark.notesvc.service;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import com.manus.noteark.notesvc.AbstractTest;
+import com.manus.noteark.notesvc.exception.NotFoundException;
+import com.manus.noteark.notesvc.pojo.Note;
+import com.manus.noteark.notesvc.repository.NoteRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import com.manus.noteark.notesvc.AbstractTest;
-import com.manus.noteark.notesvc.exception.NotFoundException;
-import com.manus.noteark.notesvc.pojo.Note;
-import com.manus.noteark.notesvc.repository.NoteRepository;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 
 public class NoteServiceTest extends AbstractTest{
 
@@ -26,8 +26,7 @@ public class NoteServiceTest extends AbstractTest{
     @Mock
     private NoteRepository noteRepositoryMock;
 
-    @BeforeAll
-    public void setUp() {
+    public NoteServiceTest() {
         MockitoAnnotations.initMocks(this);
         noteService = new NoteService(noteRepositoryMock);
     }
@@ -89,9 +88,7 @@ public class NoteServiceTest extends AbstractTest{
         when(noteRepositoryMock.findByNoteId(noteId))
             .thenReturn(Optional.empty());
 
-        assertThrows(NotFoundException.class, () -> {
-            noteService.getNoteById(noteId);
-        });
+        assertThrows(NotFoundException.class, () -> noteService.getNoteById(noteId));
     }
 
     @Test
@@ -139,8 +136,6 @@ public class NoteServiceTest extends AbstractTest{
         when(noteRepositoryMock.findByNoteId(noteId))
                 .thenReturn(Optional.empty());
 
-        assertThrows(NotFoundException.class, () -> {
-            noteService.deleteNoteWithId(noteId);
-        });
+        assertThrows(NotFoundException.class, () -> noteService.deleteNoteWithId(noteId));
     }
 }

--- a/src/test/java/com/manus/noteark/notesvc/service/NoteServiceTest.java
+++ b/src/test/java/com/manus/noteark/notesvc/service/NoteServiceTest.java
@@ -1,6 +1,6 @@
 package com.manus.noteark.notesvc.service;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
@@ -12,27 +12,21 @@ import com.manus.noteark.notesvc.exception.NotFoundException;
 import com.manus.noteark.notesvc.pojo.Note;
 import com.manus.noteark.notesvc.repository.NoteRepository;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 public class NoteServiceTest extends AbstractTest{
 
     @InjectMocks
     private NoteService noteService;
     @Mock
     private NoteRepository noteRepositoryMock;
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
-    @Before
+    @BeforeAll
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         noteService = new NoteService(noteRepositoryMock);
@@ -95,10 +89,9 @@ public class NoteServiceTest extends AbstractTest{
         when(noteRepositoryMock.findByNoteId(noteId))
             .thenReturn(Optional.empty());
 
-        expectedException.expect(NotFoundException.class);
-        expectedException.expectMessage("Could not find \"note\" with id \"1234\"");
-
-        noteService.getNoteById(noteId);
+        assertThrows(NotFoundException.class, () -> {
+            noteService.getNoteById(noteId);
+        });
     }
 
     @Test
@@ -146,9 +139,8 @@ public class NoteServiceTest extends AbstractTest{
         when(noteRepositoryMock.findByNoteId(noteId))
                 .thenReturn(Optional.empty());
 
-        expectedException.expect(NotFoundException.class);
-        expectedException.expectMessage("Could not find \"note\" with id \"1234\"");
-
-        noteService.deleteNoteWithId(noteId);
+        assertThrows(NotFoundException.class, () -> {
+            noteService.deleteNoteWithId(noteId);
+        });
     }
 }


### PR DESCRIPTION
Upgrading from junit4 to junit5:
- changing junit.jupiter, maven.surefire and maven.failsafe to compatible version
- updating mock loading to happen in test class constructor
- updating imports and annotations
- updating exception testing from using @Rule+ExpectedException to assertThrows